### PR TITLE
Fix JS typos and add contact form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# stivgraphic
+
+This project is a static portfolio site. It now includes a simple PHP script for the contact form and a Cypress test suite.
+
+## Contact form setup
+
+Edit `send-mail.php` and replace `you@example.com` with the email address that should receive contact form submissions. Ensure your PHP server is configured to send mail (e.g., via SMTP).
+
+The contact form in `contact-me.html` posts to `send-mail.php` and expects the script to return a JSON response with `{"success": true}`.
+
+## Running tests
+
+Install dependencies and execute Cypress:
+
+```bash
+npm install
+npm test
+```
+
+This will run Cypress in headless mode and execute the contact form test.

--- a/cypress/integration/contact_form.spec.js
+++ b/cypress/integration/contact_form.spec.js
@@ -1,0 +1,11 @@
+describe('Contact form', () => {
+  it('submits via ajax', () => {
+    cy.intercept('POST', '**/send-mail.php', 'success').as('contact');
+    cy.visit('contact-me.html');
+    cy.get('#name').type('Test User');
+    cy.get('#email').type('test@example.com');
+    cy.get('#message').type('Hello from Cypress');
+    cy.get('#contact-form').submit();
+    cy.wait('@contact');
+  });
+});

--- a/js/main.js
+++ b/js/main.js
@@ -9,15 +9,15 @@
   "use strict";
 
   /* global variables */
-  var portfolioKeyword = "";
-  var porftolioSingleActive = false;
-  var porftolioSingleJustClosed = false;
-  var soundEffects = false;
-  var overlay_1, overlay_2, one_page_content, tick;
-  var first_load = true;
-  var userClickedAutoplayDialog = false;
-  var homeLoaded = false;
-  var autoplay = false;
+  let portfolioKeyword = "";
+  let portfolioSingleActive = false;
+  let portfolioSingleJustClosed = false;
+  let soundEffects = false;
+  let overlay_1, overlay_2, one_page_content, tick;
+  let first_load = true;
+  let userClickedAutoplayDialog = false;
+  let homeLoaded = false;
+  let autoplay = false;
 
   /* DOCUMENT LOAD */
   $(function () {
@@ -102,9 +102,9 @@
         } else {
           // if url contains portfolio keyword
           if ($.address.path().indexOf("/" + portfolioKeyword) !== -1) {
-            if (porftolioSingleActive) {
+            if (portfolioSingleActive) {
               hideProjectDetails(true, false);
-              porftolioSingleJustClosed = false;
+              portfolioSingleJustClosed = false;
 
               // when loaded url with portfolio single url, after closing portfolio single box; open portfolio page if it is not already opened...
               if ($(".one-page-content .content-wrap").is(":empty")) {
@@ -692,7 +692,7 @@
   // ------------------------------
 
   // ------------------------------
-  // LIGHTBOX - applied to porfolio and gallery post format
+  // LIGHTBOX - applied to portfolio and gallery post format
   function setupLightbox() {
     if ($(".lightbox, .gallery, .wp-block-gallery").length) {
       $(".media-box, .gallery, .wp-block-gallery").each(function (index, element) {
@@ -1049,8 +1049,8 @@
   var pActive;
 
   function showProjectDetails(url) {
-    porftolioSingleJustClosed = true;
-    porftolioSingleActive = true;
+    portfolioSingleJustClosed = true;
+    portfolioSingleActive = true;
 
     showLoader();
 
@@ -1114,7 +1114,7 @@
   }
 
   function hideProjectDetails(forever, safeClose) {
-    porftolioSingleJustClosed = true;
+    portfolioSingleJustClosed = true;
 
     // Play Sound Effect
     if (soundEffects) {
@@ -1198,13 +1198,13 @@
     } else {
       // show page change animation
       // change page only if url doesn't target portfolio single page
-      //console.log(porftolioSingleJustClosed);
+      //console.log(portfolioSingleJustClosed);
 
-      if (porftolioSingleJustClosed) {
-        porftolioSingleJustClosed = false;
+      if (portfolioSingleJustClosed) {
+        portfolioSingleJustClosed = false;
       } else {
         if (giveDetailUrl() === -1) {
-          //porftolioSingleJustClosed = false;
+          //portfolioSingleJustClosed = false;
           var new_url = $("a[data-slug=" + path + "]").data("file-url");
           showPage(new_url);
         }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stivgraphic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "cypress run"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "cypress": "^13.7.0"
+  }
+}

--- a/send-mail.php
+++ b/send-mail.php
@@ -1,0 +1,31 @@
+<?php
+header('Content-Type: application/json');
+
+function respond($ok, $message) {
+    echo json_encode(['success' => $ok, 'message' => $message]);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respond(false, 'Invalid request method');
+}
+
+$name = trim($_POST['name'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$message = trim($_POST['message'] ?? '');
+$subject = trim($_POST['subject'] ?? 'Contact Form Submission');
+$to = 'you@example.com'; // TODO: Replace with your email address
+
+if (!$name || !$email || !$message || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    respond(false, 'Invalid form data');
+}
+
+$body = "Name: $name\nEmail: $email\nMessage:\n$message";
+$headers = "From: $name <$email>";
+
+if (mail($to, $subject, $body, $headers)) {
+    respond(true, 'success');
+} else {
+    respond(false, 'Mail send failed');
+}
+?>


### PR DESCRIPTION
## Summary
- modernize JavaScript globals in `main.js`
- correct `LIGHTBOX` comment typo
- add a simple PHP contact form handler
- document configuration and testing in `README`
- add Cypress with a contact form test
- ignore Node modules in git

## Testing
- `npm test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840a28c94e8832dbe84a369bb053a5e